### PR TITLE
Fix label not toggling checkbox

### DIFF
--- a/Test/Case/View/Helper/Bs3FormHelperTest.php
+++ b/Test/Case/View/Helper/Bs3FormHelperTest.php
@@ -731,7 +731,7 @@ class Bs3FormHelperTest extends CakeTestCase {
 		$expected = array(
 			array('div' => array('class' => 'form-group')),
 				array('div' => array('class' => 'checkbox')),
-					'<label',
+					'label' => array('for' => 'ContactActive'),
 						array('input' => array('type' => 'hidden', 'name' => 'data[Contact][active]', 'id' => 'ContactActive_', 'value' => 0)),
 						array('input' => array('type' => 'checkbox', 'name' => 'data[Contact][active]', 'value' => 1, 'id' => 'ContactActive')),
 						' My checkbox label',
@@ -750,7 +750,7 @@ class Bs3FormHelperTest extends CakeTestCase {
 				'/label',
 				array('div' => array('class' => 'col-sm-10')),
 					array('div' => array('class' => 'checkbox')),
-						'<label',
+						'label' => array('for' => 'ContactActive'),
 							array('input' => array('type' => 'hidden', 'name' => 'data[Contact][active]', 'id' => 'ContactActive_', 'value' => 0)),
 							array('input' => array('type' => 'checkbox', 'name' => 'data[Contact][active]', 'value' => 1, 'id' => 'ContactActive')),
 							' My checkbox label',

--- a/View/Helper/Bs3FormHelper.php
+++ b/View/Helper/Bs3FormHelper.php
@@ -279,7 +279,9 @@ class Bs3FormHelper extends FormHelper {
 		// Checkbox label rendering
 		if ($type == 'checkbox') {
 			if ($this->_getCustom('checkboxLabel')) {
-				$html['input'] = $this->Html->tag('label', $html['input'] . ' ' . $this->_getCustom('checkboxLabel'));
+				$options = $this->domId($args);
+				$html['input'] .= ' ' . $customOptions['checkboxLabel'];
+				$html['input'] = $this->Html->tag('label', $html['input'], array('for' => $options['id']));
 			}
 			$html['input'] = $this->Html->tag('div', $html['input'], array('class' => 'checkbox'));
 		}


### PR DESCRIPTION
If you use the `checkboxLabel` option, you cannot use the second label to toggle a checkbox (tested in Firefox). This is because checkboxes have an extra, hidden input in CakePHP.
