### PR TITLE
Fixed Regex

### DIFF
--- a/View/Helper/Bs3HtmlHelper.php
+++ b/View/Helper/Bs3HtmlHelper.php
@@ -95,7 +95,7 @@ class Bs3HtmlHelper extends HtmlHelper {
  */
 	public function getIconVendor($class) {
 		foreach ($this->_config['iconVendorPrefixes'] as $iconVendorPrefix) {
-			$regex = sprintf('/^%s-|\s%s-/', $iconVendorPrefix, $iconVendorPrefix);
+            $regex = sprintf('/^(?<!<"\')(%s[\s-]){1,}/', $iconVendorPrefix, $iconVendorPrefix);
 			if (preg_match($regex, $class)) {
 				return $iconVendorPrefix;
 			}


### PR DESCRIPTION
Fixes wrong match of regex in prepend and append.

```
'inputGroup' => array(
    'prepend' => 'fa fa-sm fa-eur',
    'append' => '<button class="btn btn-default" type="button" data-toggle="collapse" aria-expanded="false"><i class="fa fa-angle-down"></i></button>'
)
```

would cause a wrapping `<i>` breaking code.
